### PR TITLE
feat: implement tiered multipliers for trade copying

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,13 +100,42 @@ ADAPTIVE_MAX_PERCENT = 20.0
 ADAPTIVE_THRESHOLD_USD = 500.0
 
 # ==============================================================================
+# TIERED MULTIPLIERS (NEW FEATURE!)
+# ==============================================================================
+# Apply different multipliers based on trader's position size
+# Solves the problem of copying traders with varying position sizes:
+# - Small trades get higher multipliers (don't miss opportunities)
+# - Large trades get lower multipliers (prevent over-allocation)
+#
+# Format: "min-max:multiplier,min-max:multiplier,min+:multiplier"
+# - Use "min-max" for bounded ranges
+# - Use "min+" for infinite upper bound (must be last)
+# - Ranges are in USD based on trader's order size
+#
+# Example for $2k account copying a $500k-$1M trader:
+# TIERED_MULTIPLIERS = 1-10:2.0,10-100:1.0,100-500:0.2,500-1000:0.1,1000-5000:0.02,5000-10000:0.01,10000-50000:0.002,50000-100000:0.001,100000-500000:0.0005,500000+:0.0002
+#
+# What this does:
+# - $5 trader order × 2.0x = $10 copy (capture small trades)
+# - $50 trader order × 1.0x = $50 copy
+# - $500 trader order × 0.1x = $50 copy
+# - $10,000 trader order × 0.002x = $20 copy
+# - $250,000 trader order × 0.0002x = $50 copy (manage large trades)
+#
+# Simpler example for $1k account:
+# TIERED_MULTIPLIERS = 1-100:2.0,100-1000:0.5,1000-10000:0.1,10000+:0.01
+#
+# Leave unset to use single TRADE_MULTIPLIER or no multiplier (1.0x)
+
+# ==============================================================================
 # LEGACY CONFIGURATION (For backward compatibility)
 # ==============================================================================
 # These are kept for compatibility with old .env files
 # If you don't set COPY_STRATEGY, the bot will use these:
 # - COPY_PERCENTAGE: Percentage of trader's order size (default: 10.0)
-# - TRADE_MULTIPLIER: Multiplier applied to copy percentage (default: 1.0)
+# - TRADE_MULTIPLIER: Single multiplier applied to copy percentage (default: 1.0)
 # ⚠️  DEPRECATED: Please migrate to new COPY_STRATEGY system above!
+# ⚠️  NOTE: If TIERED_MULTIPLIERS is set, it overrides TRADE_MULTIPLIER
 # COPY_PERCENTAGE = 10.0
 # TRADE_MULTIPLIER = 1.0
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ The bot ensures you maintain proportional exposure relative to the traders you f
 
 - **Multi-Trader Support** - Track and copy trades from multiple traders simultaneously
 - **Smart Position Sizing** - Automatically adjusts trade sizes based on your capital
-- **Position Tracking** - Accurately tracks purchases and sells proportionally even after balance changes (NEW!)
+- **Tiered Trade Multipliers** - Apply different multipliers based on trade size - perfect for copying large traders (NEW!)
+- **Position Tracking** - Accurately tracks purchases and sells proportionally even after balance changes
 - **Trade Aggregation** - Combine multiple small trades into larger executable orders
 - **Real-time Execution** - Monitors trades every second and executes instantly
 - **Beautiful Logging** - Clean, colorful console output with structured trade information

--- a/docs/TIERED_MULTIPLIERS.md
+++ b/docs/TIERED_MULTIPLIERS.md
@@ -1,0 +1,469 @@
+# Tiered Trade Multipliers Guide
+
+## Overview
+
+Tiered trade multipliers allow you to apply different multiplier values based on the trader's position size. This powerful feature solves a critical problem when copying traders with much larger accounts than yours.
+
+## The Problem
+
+When copying a trader with a $500k-$1M account using a $2k account, you face a dilemma:
+
+- **High copy percentage (0.4%)**: Captures small trades, but a single large $500k trade would require $2,000 - your entire balance!
+- **Low copy percentage (0.004%)**: Makes large trades manageable, but you miss every trade below $250 (which is most of them)
+
+You can't win with a single fixed percentage.
+
+## The Solution
+
+Tiered multipliers apply different scaling factors based on the **trader's order size**:
+
+```
+Small trades ($1-$10)     → 2.0x multiplier  → Don't miss opportunities
+Medium trades ($10-$100)  → 1.0x multiplier  → Standard copying
+Large trades ($100-$1k)   → 0.2x multiplier  → Reduce exposure
+Huge trades ($500k+)      → 0.0002x multiplier → Manageable portions
+```
+
+## Configuration
+
+### Basic Syntax
+
+Add to your `.env` file:
+
+```bash
+TIERED_MULTIPLIERS=min-max:multiplier,min-max:multiplier,min+:multiplier
+```
+
+**Format rules:**
+- Use `min-max` for bounded ranges (e.g., `100-500:0.2`)
+- Use `min+` for infinite upper bound (e.g., `500000+:0.0002`) - must be last tier
+- Ranges are in USD based on the **trader's order size**
+- Separate tiers with commas
+
+### Example Configurations
+
+#### For $2k Account Copying $500k-$1M Trader
+
+```bash
+TIERED_MULTIPLIERS=1-10:2.0,10-100:1.0,100-500:0.2,500-1000:0.1,1000-5000:0.02,5000-10000:0.01,10000-50000:0.002,50000-100000:0.001,100000-500000:0.0005,500000+:0.0002
+```
+
+**What this does:**
+| Trader Order | Multiplier | Your Copy Trade |
+|--------------|------------|-----------------|
+| $5           | 2.0x       | $10             |
+| $50          | 1.0x       | $50             |
+| $500         | 0.1x       | $50             |
+| $10,000      | 0.002x     | $20             |
+| $250,000     | 0.0002x    | $50             |
+
+#### For $1k Account (Simpler)
+
+```bash
+TIERED_MULTIPLIERS=1-100:2.0,100-1000:0.5,1000-10000:0.1,10000+:0.01
+```
+
+**What this does:**
+| Trader Order | Multiplier | Your Copy Trade |
+|--------------|------------|-----------------|
+| $50          | 2.0x       | $100            |
+| $500         | 0.5x       | $250            |
+| $5,000       | 0.1x       | $500            |
+| $50,000      | 0.01x      | $500            |
+
+#### For $500 Account (Conservative)
+
+```bash
+TIERED_MULTIPLIERS=1-50:1.5,50-500:0.5,500-5000:0.1,5000+:0.01
+```
+
+## How It Works
+
+### 1. **Integration with Copy Strategies**
+
+Tiered multipliers work with **all copy strategies**:
+
+```bash
+# With PERCENTAGE strategy
+COPY_STRATEGY=PERCENTAGE
+COPY_SIZE=10.0  # 10% of trader's order
+TIERED_MULTIPLIERS=1-100:2.0,100-1000:0.5,1000+:0.1
+
+# $50 trader order:
+# Step 1: 10% × $50 = $5 (base amount)
+# Step 2: $5 × 2.0x (tier multiplier) = $10 (final amount)
+```
+
+```bash
+# With FIXED strategy
+COPY_STRATEGY=FIXED
+COPY_SIZE=25.0  # Fixed $25 per trade
+TIERED_MULTIPLIERS=1-1000:2.0,1000+:0.1
+
+# $100 trader order:
+# Step 1: Fixed $25 (base amount)
+# Step 2: $25 × 2.0x (tier multiplier) = $50 (final amount)
+```
+
+### 2. **BUY and SELL Symmetry**
+
+Tiered multipliers apply to both BUY and SELL orders:
+
+**Example:**
+- Trader buys $10,000 (tier: 0.01x)
+- You buy: $10,000 × 10% × 0.01x = $10
+
+Later:
+- Trader sells 50% of their position ($5,000 worth)
+- You sell: 50% of your position × 0.01x (same tier)
+
+The multiplier is always based on the **trader's current order size**, ensuring consistent scaling.
+
+### 3. **Safety Limits Still Apply**
+
+Tiered multipliers don't bypass safety limits:
+
+```bash
+MAX_ORDER_SIZE_USD=100.0
+MIN_ORDER_SIZE_USD=1.0
+TIERED_MULTIPLIERS=1-100:5.0,100+:0.1
+```
+
+Even with 5.0x multiplier, orders are still:
+- ✅ Capped at `MAX_ORDER_SIZE_USD` ($100)
+- ✅ Capped by available balance
+- ✅ Rejected if below `MIN_ORDER_SIZE_USD` ($1)
+
+## Use Cases
+
+### Use Case 1: Copy High-Volume Micro Traders
+
+**Problem:** Trader makes 50+ small trades ($10-$50) daily. With 10% copy rate, most fall below Polymarket's $1 minimum.
+
+**Solution:**
+```bash
+COPY_PERCENTAGE=10.0
+TIERED_MULTIPLIERS=1-100:3.0,100-1000:1.0,1000+:0.5
+```
+
+Now $5 trades → $1.50 (10% × 3.0x) = above minimum ✅
+
+### Use Case 2: Copy Whale with Occasional Huge Positions
+
+**Problem:** Trader usually makes $100-$1k trades, but occasionally drops $100k+ on high-conviction bets.
+
+**Solution:**
+```bash
+COPY_STRATEGY=PERCENTAGE
+COPY_SIZE=10.0
+TIERED_MULTIPLIERS=1-1000:1.0,1000-10000:0.5,10000-100000:0.1,100000+:0.01
+```
+
+- Regular trades: Normal 10% copying
+- $100k trades: Only 0.1% effective rate (10% × 0.01x)
+
+### Use Case 3: Aggressive on Small Bets, Conservative on Large
+
+**Problem:** Want to maximize exposure to trader's small "test" bets, but limit exposure to big swings.
+
+**Solution:**
+```bash
+COPY_STRATEGY=PERCENTAGE
+COPY_SIZE=5.0  # Conservative base 5%
+TIERED_MULTIPLIERS=1-50:4.0,50-500:2.0,500-5000:1.0,5000+:0.2
+```
+
+- $10 trades: 5% × 4.0x = 20% effective
+- $10,000 trades: 5% × 0.2x = 1% effective
+
+## Best Practices
+
+### 1. **Design Your Tiers Based on Trader Behavior**
+
+Analyze the trader's history:
+```bash
+# If trader makes:
+# - 60% of trades: $10-$100
+# - 30% of trades: $100-$1,000
+# - 10% of trades: $1,000-$10,000
+
+# Design tiers around these ranges:
+TIERED_MULTIPLIERS=10-100:1.5,100-1000:1.0,1000-10000:0.3,10000+:0.1
+```
+
+### 2. **Start Conservative, Then Adjust**
+
+Begin with narrow multiplier ranges:
+```bash
+# Initial (safe)
+TIERED_MULTIPLIERS=1-1000:1.0,1000+:0.5
+
+# After testing (more aggressive)
+TIERED_MULTIPLIERS=1-100:2.0,100-1000:1.0,1000+:0.2
+```
+
+### 3. **Ensure No Gaps in Coverage**
+
+❌ **Bad (gaps):**
+```bash
+TIERED_MULTIPLIERS=1-100:2.0,200-1000:1.0  # Gap: $100-$200 missing!
+```
+
+✅ **Good (continuous):**
+```bash
+TIERED_MULTIPLIERS=1-100:2.0,100-1000:1.0,1000+:0.5
+```
+
+### 4. **Combine with MAX_ORDER_SIZE_USD**
+
+Use tiers for scaling, but set absolute caps:
+```bash
+TIERED_MULTIPLIERS=1-100:5.0,100-1000:2.0,1000+:0.5
+MAX_ORDER_SIZE_USD=100.0  # Never risk more than $100 per trade
+```
+
+### 5. **Account for Your Balance**
+
+If you have $2,000 balance and copy at 5% per trade:
+```bash
+# With 1.0x max multiplier, max risk = $100 per trade
+TIERED_MULTIPLIERS=1-500:1.0,500-5000:0.2,5000+:0.05
+MAX_ORDER_SIZE_USD=100.0
+```
+
+## Backward Compatibility
+
+### Single TRADE_MULTIPLIER (Legacy)
+
+Old configuration still works:
+```bash
+COPY_PERCENTAGE=10.0
+TRADE_MULTIPLIER=2.0  # Simple 2x multiplier for all trades
+```
+
+### Priority Order
+
+If both are set, tiered multipliers take precedence:
+```bash
+TRADE_MULTIPLIER=2.0  # ← Ignored
+TIERED_MULTIPLIERS=1-100:5.0,100+:0.1  # ← Used
+```
+
+## Monitoring
+
+### Log Messages
+
+The bot shows which tier is applied:
+
+```
+ℹ 10% of trader's $5.00 = $0.50 → 2x multiplier: $0.50 → $1.00
+✓ Order size: $1.00 (within limits)
+
+ℹ 10% of trader's $250000.00 = $25000.00 → 0.0002x multiplier: $25000.00 → $50.00
+✓ Order size: $50.00 (within limits)
+```
+
+### Startup Message
+
+When bot starts with tiered multipliers:
+```
+✓ Loaded 10 tiered multipliers
+```
+
+## Troubleshooting
+
+### "Overlapping tiers" Error
+
+**Error:**
+```
+Failed to parse TIERED_MULTIPLIERS: Overlapping tiers: [100-500] and [400-1000]
+```
+
+**Fix:** Ensure tier ranges don't overlap:
+```bash
+# ❌ Bad
+TIERED_MULTIPLIERS=100-500:1.0,400-1000:0.5
+
+# ✅ Good
+TIERED_MULTIPLIERS=100-500:1.0,500-1000:0.5
+```
+
+### "Invalid tier format" Error
+
+**Error:**
+```
+Failed to parse TIERED_MULTIPLIERS: Invalid tier format: "100"
+```
+
+**Fix:** Each tier needs a range and multiplier:
+```bash
+# ❌ Bad
+TIERED_MULTIPLIERS=100:1.0
+
+# ✅ Good
+TIERED_MULTIPLIERS=100-1000:1.0
+# or
+TIERED_MULTIPLIERS=100+:1.0
+```
+
+### "Infinite upper bound must be last" Error
+
+**Error:**
+```
+Failed to parse TIERED_MULTIPLIERS: Tier with infinite upper bound must be last: 1000+
+```
+
+**Fix:** Put infinite tier (`+`) at the end:
+```bash
+# ❌ Bad
+TIERED_MULTIPLIERS=1000+:0.1,100-1000:1.0
+
+# ✅ Good
+TIERED_MULTIPLIERS=100-1000:1.0,1000+:0.1
+```
+
+### Still Missing Small Trades
+
+**Problem:** Even with high multiplier, small trades below $1 are skipped.
+
+**Check:**
+1. Verify `MIN_ORDER_SIZE_USD`:
+   ```bash
+   MIN_ORDER_SIZE_USD=1.0  # Polymarket minimum
+   ```
+
+2. Calculate effective copy amount:
+   ```
+   Trader order: $3
+   Copy %: 10%
+   Multiplier: 2.0x
+
+   Final: $3 × 10% × 2.0x = $0.60 ← Below $1 minimum!
+   ```
+
+3. **Solution:** Increase multiplier or base copy percentage:
+   ```bash
+   # Increase tier multiplier
+   TIERED_MULTIPLIERS=1-10:5.0,10-100:2.0,100+:1.0
+
+   # Or increase base copy percentage
+   COPY_SIZE=20.0  # Instead of 10.0
+   ```
+
+### Orders Capped at MAX_ORDER_SIZE
+
+**Problem:** All large orders are capped at $100.
+
+**Check `MAX_ORDER_SIZE_USD`:**
+```bash
+MAX_ORDER_SIZE_USD=100.0  # This is the cap
+
+# If you want larger orders, increase it:
+MAX_ORDER_SIZE_USD=500.0
+```
+
+## Complete Example Configuration
+
+Here's a complete `.env` configuration for a $2,000 account copying a $800,000 trader:
+
+```bash
+# ============================================
+# Copy Strategy
+# ============================================
+COPY_STRATEGY=PERCENTAGE
+COPY_SIZE=10.0  # Base 10% of trader's orders
+
+# ============================================
+# Tiered Multipliers
+# ============================================
+# Designed for $800k trader → $2k account
+TIERED_MULTIPLIERS=1-10:3.0,10-50:2.0,50-100:1.5,100-500:1.0,500-1000:0.5,1000-5000:0.1,5000-10000:0.05,10000-50000:0.01,50000-100000:0.005,100000+:0.001
+
+# ============================================
+# Safety Limits
+# ============================================
+MAX_ORDER_SIZE_USD=150.0     # Never more than $150 per trade (7.5% of balance)
+MIN_ORDER_SIZE_USD=1.0       # Polymarket minimum
+MAX_POSITION_SIZE_USD=500.0  # Never more than $500 in one market (25% of balance)
+MAX_DAILY_VOLUME_USD=1000.0  # Never more than $1k per day (50% of balance)
+```
+
+**Expected behavior:**
+| Trader Order | Calculation | Your Copy |
+|--------------|-------------|-----------|
+| $5 | $5 × 10% × 3.0x | $1.50 |
+| $25 | $25 × 10% × 2.0x | $5.00 |
+| $75 | $75 × 10% × 1.5x | $11.25 |
+| $300 | $300 × 10% × 1.0x | $30.00 |
+| $750 | $750 × 10% × 0.5x | $37.50 |
+| $3,000 | $3,000 × 10% × 0.1x | $30.00 |
+| $8,000 | $8,000 × 10% × 0.05x | $40.00 |
+| $25,000 | $25,000 × 10% × 0.01x | $25.00 |
+| $75,000 | $75,000 × 10% × 0.005x | $37.50 |
+| $500,000 | $500,000 × 10% × 0.001x | $50.00 |
+
+## Advanced: Calculating Your Tiers
+
+### Step 1: Analyze Trader's Order Distribution
+
+Check their trade history and group by size:
+```
+$1-$100: 45% of trades
+$100-$1,000: 30% of trades
+$1,000-$10,000: 20% of trades
+$10,000+: 5% of trades
+```
+
+### Step 2: Determine Your Risk Tolerance
+
+For a $2,000 account:
+- Low risk: Max $20 per trade (1%)
+- Medium risk: Max $50 per trade (2.5%)
+- High risk: Max $100 per trade (5%)
+
+### Step 3: Calculate Multipliers
+
+Target: $30 average copy trade size
+
+```
+For $50 average trader order (45% of trades):
+$50 × 10% × M = $30
+M = 30 / 5 = 6.0x
+
+For $500 average trader order (30% of trades):
+$500 × 10% × M = $30
+M = 30 / 50 = 0.6x
+
+For $5,000 average trader order (20% of trades):
+$5,000 × 10% × M = $30
+M = 30 / 500 = 0.06x
+
+For $50,000 average trader order (5% of trades):
+$50,000 × 10% × M = $30
+M = 30 / 5,000 = 0.006x
+```
+
+### Step 4: Apply and Tune
+
+```bash
+TIERED_MULTIPLIERS=1-100:6.0,100-1000:0.6,1000-10000:0.06,10000+:0.006
+MAX_ORDER_SIZE_USD=50.0  # Safety cap
+```
+
+Monitor for a week and adjust based on:
+- Are you missing profitable small trades? → Increase small-tier multipliers
+- Are large trades too risky? → Decrease large-tier multipliers
+- Hitting MAX_ORDER_SIZE too often? → Increase cap or decrease multipliers
+
+## Summary
+
+**Tiered multipliers solve the fundamental problem of copying large traders with small accounts.**
+
+Key benefits:
+- ✅ Don't miss small trades that fall below minimum order size
+- ✅ Don't over-allocate to large trades that would drain your balance
+- ✅ Automatically scale your copies proportionally to trader's behavior
+- ✅ Maintain symmetry between BUY and SELL operations
+- ✅ Work seamlessly with all copy strategies (PERCENTAGE, FIXED, ADAPTIVE)
+
+Start with a simple 3-4 tier configuration and refine based on your results!

--- a/src/config/__tests__/copyStrategy.test.ts
+++ b/src/config/__tests__/copyStrategy.test.ts
@@ -1,5 +1,11 @@
-import { calculateOrderSize, CopyStrategy, validateCopyStrategyConfig } from '../copyStrategy';
 import type { CopyStrategyConfig } from '../copyStrategy';
+import {
+    calculateOrderSize,
+    CopyStrategy,
+    getTradeMultiplier,
+    parseTieredMultipliers,
+    validateCopyStrategyConfig
+} from '../copyStrategy';
 
 describe('calculateOrderSize', () => {
     const baseConfig: CopyStrategyConfig = {
@@ -127,3 +133,182 @@ describe('validateCopyStrategyConfig', () => {
         expect(errors.some((e) => e.includes('minOrderSizeUSD'))).toBe(true);
     });
 });
+
+describe('parseTieredMultipliers', () => {
+    it('should parse valid tiered multipliers', () => {
+        const input = '1-10:2.0,10-100:1.0,100-500:0.2,500+:0.1';
+        const tiers = parseTieredMultipliers(input);
+
+        expect(tiers).toHaveLength(4);
+        expect(tiers[0]).toEqual({ min: 1, max: 10, multiplier: 2.0 });
+        expect(tiers[1]).toEqual({ min: 10, max: 100, multiplier: 1.0 });
+        expect(tiers[2]).toEqual({ min: 100, max: 500, multiplier: 0.2 });
+        expect(tiers[3]).toEqual({ min: 500, max: null, multiplier: 0.1 });
+    });
+
+    it('should handle infinite upper bound', () => {
+        const input = '1000+:0.001';
+        const tiers = parseTieredMultipliers(input);
+
+        expect(tiers).toHaveLength(1);
+        expect(tiers[0]).toEqual({ min: 1000, max: null, multiplier: 0.001 });
+    });
+
+    it('should return empty array for empty string', () => {
+        const tiers = parseTieredMultipliers('');
+        expect(tiers).toHaveLength(0);
+    });
+
+    it('should throw error for invalid format', () => {
+        expect(() => parseTieredMultipliers('invalid')).toThrow('Invalid tier format');
+        expect(() => parseTieredMultipliers('100:0.5')).toThrow('Invalid range format');
+        expect(() => parseTieredMultipliers('100-50:0.5')).toThrow('Invalid maximum value');
+    });
+
+    it('should throw error for overlapping tiers', () => {
+        const input = '1-100:2.0,50-200:1.0';
+        expect(() => parseTieredMultipliers(input)).toThrow('Overlapping tiers');
+    });
+
+    it('should throw error for infinite tier not at end', () => {
+        const input = '1-100:2.0,100+:1.0,200-300:0.5';
+        expect(() => parseTieredMultipliers(input)).toThrow('infinite upper bound must be last');
+    });
+
+    it('should throw error for invalid multiplier', () => {
+        expect(() => parseTieredMultipliers('100-200:abc')).toThrow('Invalid multiplier');
+        expect(() => parseTieredMultipliers('100-200:-1')).toThrow('Invalid multiplier');
+    });
+});
+
+describe('getTradeMultiplier', () => {
+    const tieredConfig: CopyStrategyConfig = {
+        strategy: CopyStrategy.PERCENTAGE,
+        copySize: 10.0,
+        maxOrderSizeUSD: 1000.0,
+        minOrderSizeUSD: 1.0,
+        tieredMultipliers: [
+            { min: 1, max: 10, multiplier: 2.0 },
+            { min: 10, max: 100, multiplier: 1.0 },
+            { min: 100, max: 500, multiplier: 0.2 },
+            { min: 500, max: 1000, multiplier: 0.1 },
+            { min: 1000, max: 5000, multiplier: 0.02 },
+            { min: 5000, max: null, multiplier: 0.001 }
+        ]
+    };
+
+    it('should return correct multiplier for small trades', () => {
+        expect(getTradeMultiplier(tieredConfig, 5)).toBe(2.0);
+        expect(getTradeMultiplier(tieredConfig, 9.99)).toBe(2.0);
+    });
+
+    it('should return correct multiplier for medium trades', () => {
+        expect(getTradeMultiplier(tieredConfig, 10)).toBe(1.0);
+        expect(getTradeMultiplier(tieredConfig, 50)).toBe(1.0);
+        expect(getTradeMultiplier(tieredConfig, 100)).toBe(0.2);
+        expect(getTradeMultiplier(tieredConfig, 250)).toBe(0.2);
+    });
+
+    it('should return correct multiplier for large trades', () => {
+        expect(getTradeMultiplier(tieredConfig, 500)).toBe(0.1);
+        expect(getTradeMultiplier(tieredConfig, 1000)).toBe(0.02);
+        expect(getTradeMultiplier(tieredConfig, 5000)).toBe(0.001);
+        expect(getTradeMultiplier(tieredConfig, 100000)).toBe(0.001);
+    });
+
+    it('should return 1.0 if no tiered multipliers configured', () => {
+        const noTierConfig: CopyStrategyConfig = {
+            strategy: CopyStrategy.PERCENTAGE,
+            copySize: 10.0,
+            maxOrderSizeUSD: 100.0,
+            minOrderSizeUSD: 1.0,
+        };
+        expect(getTradeMultiplier(noTierConfig, 100)).toBe(1.0);
+    });
+
+    it('should use single multiplier if configured', () => {
+        const singleMultiplierConfig: CopyStrategyConfig = {
+            strategy: CopyStrategy.PERCENTAGE,
+            copySize: 10.0,
+            maxOrderSizeUSD: 100.0,
+            minOrderSizeUSD: 1.0,
+            tradeMultiplier: 2.5
+        };
+        expect(getTradeMultiplier(singleMultiplierConfig, 100)).toBe(2.5);
+    });
+
+    it('should prefer tiered multipliers over single multiplier', () => {
+        const bothConfig: CopyStrategyConfig = {
+            ...tieredConfig,
+            tradeMultiplier: 5.0 // Should be ignored
+        };
+        expect(getTradeMultiplier(bothConfig, 5)).toBe(2.0); // Uses tiered
+    });
+});
+
+describe('calculateOrderSize with tiered multipliers', () => {
+    const tieredConfig: CopyStrategyConfig = {
+        strategy: CopyStrategy.PERCENTAGE,
+        copySize: 10.0, // 10%
+        maxOrderSizeUSD: 1000.0,
+        minOrderSizeUSD: 1.0,
+        tieredMultipliers: [
+            { min: 1, max: 10, multiplier: 2.0 },
+            { min: 10, max: 100, multiplier: 1.0 },
+            { min: 100, max: 1000, multiplier: 0.2 },
+            { min: 1000, max: null, multiplier: 0.01 }
+        ]
+    };
+
+    it('should apply 2.0x multiplier for small trades ($1-$10)', () => {
+        // $5 trade × 10% = $0.50 × 2.0x = $1.00
+        const result = calculateOrderSize(tieredConfig, 5, 1000, 0);
+        expect(result.baseAmount).toBe(0.5);
+        expect(result.finalAmount).toBe(1.0);
+    });
+
+    it('should apply 1.0x multiplier for medium trades ($10-$100)', () => {
+        // $50 trade × 10% = $5.00 × 1.0x = $5.00
+        const result = calculateOrderSize(tieredConfig, 50, 1000, 0);
+        expect(result.finalAmount).toBe(5.0);
+    });
+
+    it('should apply 0.2x multiplier for large trades ($100-$1000)', () => {
+        // $500 trade × 10% = $50.00 × 0.2x = $10.00
+        const result = calculateOrderSize(tieredConfig, 500, 1000, 0);
+        expect(result.finalAmount).toBe(10.0);
+    });
+
+    it('should apply 0.01x multiplier for very large trades ($1000+)', () => {
+        // $250,000 trade × 10% = $25,000 × 0.01x = $250
+        const result = calculateOrderSize(tieredConfig, 250000, 10000, 0);
+        expect(result.finalAmount).toBe(250.0);
+    });
+
+    it('should include multiplier in reasoning', () => {
+        const result = calculateOrderSize(tieredConfig, 5, 1000, 0);
+        expect(result.reasoning).toContain('2x multiplier');
+    });
+
+    it('should work with FIXED strategy', () => {
+        const fixedTieredConfig: CopyStrategyConfig = {
+            strategy: CopyStrategy.FIXED,
+            copySize: 50.0, // Fixed $50
+            maxOrderSizeUSD: 1000.0,
+            minOrderSizeUSD: 1.0,
+            tieredMultipliers: [
+                { min: 1, max: 1000, multiplier: 2.0 },
+                { min: 1000, max: null, multiplier: 0.1 }
+            ]
+        };
+
+        // Small trader order ($100) → fixed $50 × 2.0x = $100
+        const smallResult = calculateOrderSize(fixedTieredConfig, 100, 1000, 0);
+        expect(smallResult.finalAmount).toBe(100.0);
+
+        // Large trader order ($10,000) → fixed $50 × 0.1x = $5
+        const largeResult = calculateOrderSize(fixedTieredConfig, 10000, 1000, 0);
+        expect(largeResult.finalAmount).toBe(5.0);
+    });
+});
+

--- a/src/utils/postOrder.ts
+++ b/src/utils/postOrder.ts
@@ -3,7 +3,7 @@ import { ENV } from '../config/env';
 import { UserActivityInterface, UserPositionInterface } from '../interfaces/User';
 import { getUserActivityModel } from '../models/userHistory';
 import Logger from './logger';
-import { calculateOrderSize } from '../config/copyStrategy';
+import { calculateOrderSize, getTradeMultiplier } from '../config/copyStrategy';
 
 const RETRY_LIMIT = ENV.RETRY_LIMIT;
 const COPY_STRATEGY_CONFIG = ENV.COPY_STRATEGY_CONFIG;
@@ -362,12 +362,13 @@ const postOrder = async (
                 );
             }
 
-            // Apply multiplier symmetrically with BUY logic
-            remaining = baseSellSize * TRADE_MULTIPLIER;
+            // Apply tiered or single multiplier based on trader's order size (symmetrical with BUY logic)
+            const multiplier = getTradeMultiplier(COPY_STRATEGY_CONFIG, trade.usdcSize);
+            remaining = baseSellSize * multiplier;
 
-            if (TRADE_MULTIPLIER !== 1.0) {
+            if (multiplier !== 1.0) {
                 Logger.info(
-                    `Applying ${TRADE_MULTIPLIER}x multiplier: ${baseSellSize.toFixed(2)} → ${remaining.toFixed(2)} tokens`
+                    `Applying ${multiplier}x multiplier (based on trader's $${trade.usdcSize.toFixed(2)} order): ${baseSellSize.toFixed(2)} → ${remaining.toFixed(2)} tokens`
                 );
             }
         }


### PR DESCRIPTION
- Introduced a new feature for tiered multipliers in the .env.example, allowing different multipliers based on trader's position size.
- Updated the CopyStrategyConfig interface to include tiered multipliers and modified the order size calculation to apply these multipliers.
- Enhanced the parsing logic for tiered multipliers in env.ts, ensuring backward compatibility with the legacy TRADE_MULTIPLIER.
- Added comprehensive tests for the new tiered multipliers functionality, including validation for input formats and expected behavior.