### PR TITLE
fix: implement PREVIEW_MODE and fix silent trade loss on execution failure

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -296,4 +296,5 @@ export const ENV = {
     // Auto-resolve settings (automatically sell positions at 100% or 0%)
     AUTO_RESOLVE_ENABLED: process.env.AUTO_RESOLVE_ENABLED === 'true',
     AUTO_RESOLVE_INTERVAL: parseInt(process.env.AUTO_RESOLVE_INTERVAL || '60', 10), // Check every 60s by default
+    PREVIEW_MODE: process.env.PREVIEW_MODE === 'true',
 };

--- a/src/services/tradeExecutor.ts
+++ b/src/services/tradeExecutor.ts
@@ -160,40 +160,46 @@ const doTrading = async (clobClient: ClobClient, trades: TradeWithUser[]) => {
             transactionHash: trade.transactionHash,
         });
 
-        const my_positions: UserPositionInterface[] = await fetchData(
-            `https://data-api.polymarket.com/positions?user=${PROXY_WALLET}`
-        );
-        const user_positions: UserPositionInterface[] = await fetchData(
-            `https://data-api.polymarket.com/positions?user=${trade.userAddress}`
-        );
-        const my_position = my_positions.find(
-            (position: UserPositionInterface) => position.conditionId === trade.conditionId
-        );
-        const user_position = user_positions.find(
-            (position: UserPositionInterface) => position.conditionId === trade.conditionId
-        );
+        try {
+            const my_positions: UserPositionInterface[] = await fetchData(
+                `https://data-api.polymarket.com/positions?user=${PROXY_WALLET}`
+            );
+            const user_positions: UserPositionInterface[] = await fetchData(
+                `https://data-api.polymarket.com/positions?user=${trade.userAddress}`
+            );
+            const my_position = my_positions.find(
+                (position: UserPositionInterface) => position.conditionId === trade.conditionId
+            );
+            const user_position = user_positions.find(
+                (position: UserPositionInterface) => position.conditionId === trade.conditionId
+            );
 
-        // Get USDC balance
-        const my_balance = await getMyBalance(PROXY_WALLET);
+            // Get USDC balance
+            const my_balance = await getMyBalance(PROXY_WALLET);
 
-        // Calculate trader's total portfolio value from positions
-        const user_balance = user_positions.reduce((total, pos) => {
-            return total + (pos.currentValue || 0);
-        }, 0);
+            // Calculate trader's total portfolio value from positions
+            const user_balance = user_positions.reduce((total, pos) => {
+                return total + (pos.currentValue || 0);
+            }, 0);
 
-        Logger.balance(my_balance, user_balance, trade.userAddress);
+            Logger.balance(my_balance, user_balance, trade.userAddress);
 
-        // Execute the trade
-        await postOrder(
-            clobClient,
-            trade.side === 'BUY' ? 'buy' : 'sell',
-            my_position,
-            user_position,
-            trade,
-            my_balance,
-            user_balance,
-            trade.userAddress
-        );
+            // Execute the trade
+            await postOrder(
+                clobClient,
+                trade.side === 'BUY' ? 'buy' : 'sell',
+                my_position,
+                user_position,
+                trade,
+                my_balance,
+                user_balance,
+                trade.userAddress
+            );
+        } catch (err) {
+            // Reset in-progress marker so the trade is retried on the next poll cycle
+            await UserActivity.updateOne({ _id: trade._id }, { $set: { botExcutedTime: 0 } });
+            Logger.error(`Trade execution failed, will retry: ${err}`);
+        }
 
         Logger.separator();
     }
@@ -216,48 +222,57 @@ const doAggregatedTrading = async (clobClient: ClobClient, aggregatedTrades: Agg
             await UserActivity.updateOne({ _id: trade._id }, { $set: { botExcutedTime: 1 } });
         }
 
-        const my_positions: UserPositionInterface[] = await fetchData(
-            `https://data-api.polymarket.com/positions?user=${PROXY_WALLET}`
-        );
-        const user_positions: UserPositionInterface[] = await fetchData(
-            `https://data-api.polymarket.com/positions?user=${agg.userAddress}`
-        );
-        const my_position = my_positions.find(
-            (position: UserPositionInterface) => position.conditionId === agg.conditionId
-        );
-        const user_position = user_positions.find(
-            (position: UserPositionInterface) => position.conditionId === agg.conditionId
-        );
+        try {
+            const my_positions: UserPositionInterface[] = await fetchData(
+                `https://data-api.polymarket.com/positions?user=${PROXY_WALLET}`
+            );
+            const user_positions: UserPositionInterface[] = await fetchData(
+                `https://data-api.polymarket.com/positions?user=${agg.userAddress}`
+            );
+            const my_position = my_positions.find(
+                (position: UserPositionInterface) => position.conditionId === agg.conditionId
+            );
+            const user_position = user_positions.find(
+                (position: UserPositionInterface) => position.conditionId === agg.conditionId
+            );
 
-        // Get USDC balance
-        const my_balance = await getMyBalance(PROXY_WALLET);
+            // Get USDC balance
+            const my_balance = await getMyBalance(PROXY_WALLET);
 
-        // Calculate trader's total portfolio value from positions
-        const user_balance = user_positions.reduce((total, pos) => {
-            return total + (pos.currentValue || 0);
-        }, 0);
+            // Calculate trader's total portfolio value from positions
+            const user_balance = user_positions.reduce((total, pos) => {
+                return total + (pos.currentValue || 0);
+            }, 0);
 
-        Logger.balance(my_balance, user_balance, agg.userAddress);
+            Logger.balance(my_balance, user_balance, agg.userAddress);
 
-        // Create a synthetic trade object for postOrder using aggregated values
-        const syntheticTrade: UserActivityInterface = {
-            ...agg.trades[0], // Use first trade as template
-            usdcSize: agg.totalUsdcSize,
-            price: agg.averagePrice,
-            side: agg.side as 'BUY' | 'SELL',
-        };
+            // Create a synthetic trade object for postOrder using aggregated values
+            const syntheticTrade: UserActivityInterface = {
+                ...agg.trades[0], // Use first trade as template
+                usdcSize: agg.totalUsdcSize,
+                price: agg.averagePrice,
+                side: agg.side as 'BUY' | 'SELL',
+            };
 
-        // Execute the aggregated trade
-        await postOrder(
-            clobClient,
-            agg.side === 'BUY' ? 'buy' : 'sell',
-            my_position,
-            user_position,
-            syntheticTrade,
-            my_balance,
-            user_balance,
-            agg.userAddress
-        );
+            // Execute the aggregated trade
+            await postOrder(
+                clobClient,
+                agg.side === 'BUY' ? 'buy' : 'sell',
+                my_position,
+                user_position,
+                syntheticTrade,
+                my_balance,
+                user_balance,
+                agg.userAddress
+            );
+        } catch (err) {
+            // Reset in-progress marker on all constituent trades so they can be retried
+            for (const trade of agg.trades) {
+                const UserActivity = getUserActivityModel(trade.userAddress);
+                await UserActivity.updateOne({ _id: trade._id }, { $set: { botExcutedTime: 0 } });
+            }
+            Logger.error(`Aggregated trade execution failed, will retry: ${err}`);
+        }
 
         Logger.separator();
     }

--- a/src/utils/postOrder.ts
+++ b/src/utils/postOrder.ts
@@ -74,6 +74,15 @@ const postOrder = async (
     userAddress: string
 ) => {
     const UserActivity = getUserActivityModel(userAddress);
+
+    if (ENV.PREVIEW_MODE) {
+        Logger.info(
+            `[PREVIEW] Would execute ${condition.toUpperCase()} — asset: ${trade.asset}, size: $${trade.usdcSize.toFixed(2)} @ $${trade.price}`
+        );
+        await UserActivity.updateOne({ _id: trade._id }, { bot: true });
+        return;
+    }
+
     //Merge strategy
     if (condition === 'merge') {
         Logger.info('Executing MERGE strategy...');


### PR DESCRIPTION
## Summary

- **PREVIEW_MODE was never enforced** — the flag existed in `.env.example` and the web dashboard but `ENV.PREVIEW_MODE` was never parsed, so trades executed unconditionally. Added the parse in `src/config/env.ts` and an early-return guard in `postOrder()` that logs the would-be action and marks the trade processed without placing any real orders.
- **Silent trade loss on execution failure** — `tradeExecutor.ts` set `botExcutedTime: 1` (the in-progress marker) *before* calling `postOrder()`. If the network call, API call, or order itself threw an exception, the trade was left with `botExcutedTime: 1, bot: false` — invisible to the next poll cycle and permanently lost. Wrapped the execute block in try/catch in both `doTrading` and `doAggregatedTrading`; on failure, resets `botExcutedTime` back to `0` so the trade is retried.

## Files changed

| File | Change |
|---|---|
| `src/config/env.ts` | Parse `PREVIEW_MODE` env var as boolean |
| `src/utils/postOrder.ts` | Early-return guard at top of `postOrder()` when `PREVIEW_MODE=true` |
| `src/services/tradeExecutor.ts` | try/catch around execute block in `doTrading` + `doAggregatedTrading`; reset `botExcutedTime` on failure |

## Test plan

- [ ] Set `PREVIEW_MODE=true` and confirm trades are logged but no orders hit the CLOB
- [ ] Simulate a network failure during `fetchData` and confirm the trade reappears on the next poll (check MongoDB: `botExcutedTime` returns to `0`)
- [ ] Set `PREVIEW_MODE=false` (default) and confirm normal trade execution is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)